### PR TITLE
Added git clean task and tests

### DIFF
--- a/src/com.unity.git.api/Api/Git/GitClient.cs
+++ b/src/com.unity.git.api/Api/Git/GitClient.cs
@@ -324,6 +324,7 @@ namespace Unity.VersionControl.Git
     {
         private const string UserNameConfigKey = "user.name";
         private const string UserEmailConfigKey = "user.email";
+        private const int SpoolLength = 5000;
         private readonly IEnvironment environment;
         private readonly IProcessManager processManager;
         private readonly CancellationToken cancellationToken;
@@ -568,7 +569,7 @@ namespace Unity.VersionControl.Git
             IOutputProcessor<string> processor = null)
         {
             GitAddTask last = null;
-            foreach (var batch in files.Spool(5000))
+            foreach (var batch in files.Spool(SpoolLength))
             {
                 var current = new GitAddTask(batch, cancellationToken, processor).Configure(processManager);
                 if (last == null)
@@ -590,7 +591,7 @@ namespace Unity.VersionControl.Git
             IOutputProcessor<string> processor = null)
         {
             GitCheckoutTask last = null;
-            foreach (var batch in files.Spool(5000))
+            foreach (var batch in files.Spool(SpoolLength))
             {
                 var current = new GitCheckoutTask(batch, cancellationToken, processor).Configure(processManager);
                 if (last == null)
@@ -618,7 +619,7 @@ namespace Unity.VersionControl.Git
         public ITask<string> Clean(IList<string> files, IOutputProcessor<string> processor = null)
         {
             GitCleanTask last = null;
-            foreach (var batch in files.Spool(5000))
+            foreach (var batch in files.Spool(SpoolLength))
             {
                 var current = new GitCleanTask(batch, cancellationToken, processor).Configure(processManager);
                 if (last == null)
@@ -654,7 +655,7 @@ namespace Unity.VersionControl.Git
             IOutputProcessor<string> processor = null)
         {
             GitRemoveFromIndexTask last = null;
-            foreach (var batch in files.Spool(5000))
+            foreach (var batch in files.Spool(SpoolLength))
             {
                 var current = new GitRemoveFromIndexTask(batch, cancellationToken, processor).Configure(processManager);
                 if (last == null)

--- a/src/com.unity.git.api/Api/Git/GitClient.cs
+++ b/src/com.unity.git.api/Api/Git/GitClient.cs
@@ -210,6 +210,21 @@ namespace Unity.VersionControl.Git
         ITask<string> DiscardAll(IOutputProcessor<string> processor = null);
 
         /// <summary>
+        /// Executes at least one `git clean` command to discard changes to the list of untracked files.
+        /// </summary>
+        /// <param name="files">The files to clean</param>
+        /// <param name="processor">A custom output processor instance</param>
+        /// <returns>String output of git command</returns>
+        ITask<string> Clean(IList<string> files, IOutputProcessor<string> processor = null);
+
+        /// <summary>
+        /// Executes `git clean` command to discard changes to all untracked files.
+        /// </summary>
+        /// <param name="processor">A custom output processor instance</param>
+        /// <returns>String output of git command</returns>
+        ITask<string> CleanAll(IOutputProcessor<string> processor = null);
+
+        /// <summary>
         /// Executes at least one `git checkout` command to checkout files at the given changeset
         /// </summary>
         /// <param name="changeset">The md5 of the changeset</param>
@@ -571,7 +586,7 @@ namespace Unity.VersionControl.Git
         }
 
         ///<inheritdoc/>
-        public ITask<string> Discard( IList<string> files,
+        public ITask<string> Discard(IList<string> files,
             IOutputProcessor<string> processor = null)
         {
             GitCheckoutTask last = null;
@@ -596,6 +611,34 @@ namespace Unity.VersionControl.Git
         public ITask<string> DiscardAll(IOutputProcessor<string> processor = null)
         {
             return new GitCheckoutTask(cancellationToken, processor)
+                .Configure(processManager);
+        }
+
+        ///<inheritdoc/>
+        public ITask<string> Clean(IList<string> files, IOutputProcessor<string> processor = null)
+        {
+            GitCleanTask last = null;
+            foreach (var batch in files.Spool(5000))
+            {
+                var current = new GitCleanTask(batch, cancellationToken, processor).Configure(processManager);
+                if (last == null)
+                {
+                    last = current;
+                }
+                else
+                {
+                    last.Then(current);
+                    last = current;
+                }
+            }
+
+            return last;
+        }
+
+        ///<inheritdoc/>
+        public ITask<string> CleanAll(IOutputProcessor<string> processor = null)
+        {
+            return new GitCleanTask(cancellationToken, processor)
                 .Configure(processManager);
         }
 

--- a/src/com.unity.git.api/Api/Git/Tasks/GitCleanTask.cs
+++ b/src/com.unity.git.api/Api/Git/Tasks/GitCleanTask.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Unity.VersionControl.Git.Tasks
+{
+    public class GitCleanTask : ProcessTask<string>
+    {
+        private const string TaskName = "git clean";
+        private readonly string arguments;
+
+        public GitCleanTask(IEnumerable<string> files, CancellationToken token,
+            IOutputProcessor<string> processor = null) : base(token, processor ?? new SimpleOutputProcessor())
+        {
+            Guard.ArgumentNotNull(files, "files");
+            Name = TaskName;
+
+            arguments = "clean ";
+            arguments += " -f ";
+            arguments += " -q ";
+
+            foreach (var file in files)
+            {
+                arguments += " \"" + file.ToNPath().ToString(SlashMode.Forward) + "\"";
+            }
+        }
+
+        public GitCleanTask(CancellationToken token,
+            IOutputProcessor<string> processor = null) : base(token, processor ?? new SimpleOutputProcessor())
+        {
+            arguments = "clean ";
+            arguments += "-f";
+        }
+
+        public override string ProcessArguments { get { return arguments; } }
+        public override TaskAffinity Affinity { get { return TaskAffinity.Exclusive; } }
+        public override string Message { get; set; } = "Removing untracked files...";
+    }
+}

--- a/tests/IntegrationTests/Git/GitClientTests.cs
+++ b/tests/IntegrationTests/Git/GitClientTests.cs
@@ -62,9 +62,9 @@ namespace IntegrationTests
 
             GitClient.Clean(new List<string> { m_CleanFiles[0], m_CleanFiles[2] }).RunSynchronously();
 
-            File.Exists(m_CleanFiles[0]).Should().BeFalse();
-            File.Exists(m_CleanFiles[1]).Should().BeTrue();
-            File.Exists(m_CleanFiles[2]).Should().BeFalse();
+            m_CleanFiles[0].ToNPath().Exists().Should().BeFalse();
+            m_CleanFiles[1].ToNPath().Exists().Should().BeTrue();
+            m_CleanFiles[2].ToNPath().Exists().Should().BeFalse();
         }
 
         [Test]
@@ -79,9 +79,9 @@ namespace IntegrationTests
 
             GitClient.CleanAll().RunSynchronously();
 
-            File.Exists(m_CleanFiles[0]).Should().BeFalse();
-            File.Exists(m_CleanFiles[1]).Should().BeFalse();
-            File.Exists(m_CleanFiles[2]).Should().BeFalse();
+            m_CleanFiles[0].ToNPath().Exists().Should().BeFalse();
+            m_CleanFiles[1].ToNPath().Exists().Should().BeFalse();
+            m_CleanFiles[2].ToNPath().Exists().Should().BeFalse();
         }
     }
 }

--- a/tests/IntegrationTests/Git/GitClientTests.cs
+++ b/tests/IntegrationTests/Git/GitClientTests.cs
@@ -14,24 +14,7 @@ namespace IntegrationTests
     {
         protected override int Timeout { get; set; } = 5 * 60 * 1000;
 
-        readonly string[] m_CleanFiles = new[] { "file1.txt", "file2.txt", "file3.txt" };
-
-        [OneTimeTearDown]
-        public void OnOneTimeTearDown()
-        {
-            // Clean up any created files!
-            try
-            {
-                foreach (var file in m_CleanFiles)
-                {
-                    File.Delete(file);
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-        }
+        readonly string[] m_CleanFiles = { "file1.txt", "file2.txt", "file3.txt" };
 
         [Test]
         public void AaSetupGitFirst()
@@ -70,20 +53,11 @@ namespace IntegrationTests
         [Test]
         public void ShouldCleanFile()
         {
-            if (!DefaultEnvironment.OnWindows)
-                return;
-
             InitializePlatformAndEnvironment(TestRepoMasterCleanSynchronized);
 
             foreach (var file in m_CleanFiles)
             {
-                // Create the file.
-                using (var fs = File.Create(file))
-                {
-                    // Write some text to the file
-                    var info = new UTF8Encoding(true).GetBytes("Some text");
-                    fs.Write(info, 0, info.Length);
-                }
+                file.ToNPath().WriteAllText("Some test text.");
             }
 
             GitClient.Clean(new List<string> { m_CleanFiles[0], m_CleanFiles[2] }).RunSynchronously();
@@ -96,20 +70,11 @@ namespace IntegrationTests
         [Test]
         public void ShouldCleanAllFiles()
         {
-            if (!DefaultEnvironment.OnWindows)
-                return;
-
             InitializePlatformAndEnvironment(TestRepoMasterCleanSynchronized);
 
             foreach (var file in m_CleanFiles)
             {
-                // Create the file.
-                using (var fs = File.Create(file))
-                {
-                    // Write some text to the file
-                    var info = new UTF8Encoding(true).GetBytes("Some text");
-                    fs.Write(info, 0, info.Length);
-                }
+                file.ToNPath().WriteAllText("Some test text.");
             }
 
             GitClient.CleanAll().RunSynchronously();


### PR DESCRIPTION
### Description of the Change

Added a Task to allow use of the `git clean` command. The clean task is used to delete a list or all untracked files in the git repository.
Docs here: https://git-scm.com/docs/git-clean

### Alternate Designs

Right now the RepositoryManager simply uses the C# API to delete files that are untracked when discard is called. The call to it requires a GitStatusEntry -- which our UI that relies on the API doesn't have. One possibility would be to amend that API to take a filepath and a status. I chose to add support for clean command instead as it is safer (if [however unlikely] file status is changed between the status updating in the UI and the delete running), and won't require our UI to translate our abstraction back to into Git-For-Unity terms.

### Benefits

Adds clean command that could be integrated into discard or other situations and enables other UIs relying on the API to be more expressive.

### Possible Drawbacks

Larger codebase, thus more to maintain and test.

### Applicable Issues

No applicable issues.
