### PR TITLE
Make source to set git user name/email configurable

### DIFF
--- a/src/com.unity.git.api/Api/Git/GitClient.cs
+++ b/src/com.unity.git.api/Api/Git/GitClient.cs
@@ -309,8 +309,9 @@ namespace Unity.VersionControl.Git
         /// </summary>
         /// <param name="username">The username to set</param>
         /// <param name="email">The email to set</param>
+        /// <param name="configSource">The source to set the values in</param>
         /// <returns><see cref="GitUser"/> output</returns>
-        ITask<GitUser> SetConfigNameAndEmail(string username, string email);
+        ITask<GitUser> SetConfigNameAndEmail(string username, string email, GitConfigSource configSource = GitConfigSource.User);
 
         /// <summary>
         /// Executes `git rev-parse --short HEAD` to get the current commit sha of the current branch.
@@ -458,10 +459,10 @@ namespace Unity.VersionControl.Git
         }
 
         ///<inheritdoc/>
-        public ITask<GitUser> SetConfigNameAndEmail(string username, string email)
+        public ITask<GitUser> SetConfigNameAndEmail(string username, string email, GitConfigSource configSource = GitConfigSource.User)
         {
-            return SetConfig(UserNameConfigKey, username, GitConfigSource.User)
-                .Then(SetConfig(UserEmailConfigKey, email, GitConfigSource.User))
+            return SetConfig(UserNameConfigKey, username, configSource)
+                .Then(SetConfig(UserEmailConfigKey, email, configSource))
                 .Then(b => new GitUser(username, email));
         }
 


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Add an optional param to specify the location that the git user.name and user.email is stored in the `GitClient.SetConfigNameAndEmail` method. At present it is limit to setting the global value, but library users might not want to override the values already set by the user. Adding this parameter opens up the option to decide what the developer wants to set.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The other alternate would be to just copy the existing method into the code-base of the library users and change the values, but this would just constitute extra unnecessary code. 

### Benefits

<!-- What benefits will be realized by the code change? -->

The git user name/email can now be set for the local repository. Existing callers to the method will continue to work as before.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None as far as I know.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.
