### PR TITLE
Add -m option for revert

### DIFF
--- a/src/com.unity.git.api/Api/Git/GitClient.cs
+++ b/src/com.unity.git.api/Api/Git/GitClient.cs
@@ -106,9 +106,10 @@ namespace Unity.VersionControl.Git
         /// Executes `git revert` to perform a revert operation.
         /// </summary>
         /// <param name="changeset">The changeset to revert</param>
+        /// <param name="allowMergeCommits">Set to true if reverting via or to a merge commit</param>
         /// <param name="processor">A custom output processor instance</param>
         /// <returns>String output of git command</returns>
-        ITask<string> Revert(string changeset, IOutputProcessor<string> processor = null);
+        ITask<string> Revert(string changeset, bool allowMergeCommits = false, IOutputProcessor<string> processor = null);
 
         /// <summary>
         /// Executes `git fetch` to perform a fetch operation.
@@ -489,9 +490,9 @@ namespace Unity.VersionControl.Git
         }
 
         ///<inheritdoc/>
-        public ITask<string> Revert(string changeset, IOutputProcessor<string> processor = null)
+        public ITask<string> Revert(string changeset, bool allowMergeCommits = false, IOutputProcessor<string> processor = null)
         {
-            return new GitRevertTask(changeset, cancellationToken, processor)
+            return new GitRevertTask(changeset, allowMergeCommits, cancellationToken, processor)
                 .Configure(processManager);
         }
 

--- a/src/com.unity.git.api/Api/Git/Tasks/GitRevertTask.cs
+++ b/src/com.unity.git.api/Api/Git/Tasks/GitRevertTask.cs
@@ -7,13 +7,14 @@ namespace Unity.VersionControl.Git.Tasks
         private const string TaskName = "git revert";
         private readonly string arguments;
 
-        public GitRevertTask(string changeset,
+        public GitRevertTask(string changeset, bool allowMergeCommits,
             CancellationToken token, IOutputProcessor<string> processor = null)
             : base(token, processor ?? new SimpleOutputProcessor())
         {
             Guard.ArgumentNotNull(changeset, "changeset");
             Name = TaskName;
-            arguments = $"revert --no-edit {changeset}";
+            var merge = allowMergeCommits ? "-m" : string.Empty;
+            arguments = $"revert --no-edit {merge} {changeset}";
         }
 
         public override string ProcessArguments { get { return arguments; } }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When using the library to execute a command like `git revert --no-edit 127eab9ea4dbe7ac6bc52676a2ed48668cb1623d..`, I found an issue. If there are any commits between HEAD and target that are merge commits, the command fails and leaves git in a revert in progress state. To stop this from happening, I've added the -m revert option as a configurable option for the revert task.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
There are no reasonable alternates for this change.

### Benefits

<!-- What benefits will be realized by the code change? -->
Ability to revert for a range with merge commits in the range.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Increased scope of the codebase.

### Applicable Issues

<!-- Enter any applicable Issues here -->
