### PR TITLE
Fix Pack-Npm.ps1 cannot create packages

### DIFF
--- a/scripts/Pack-Npm.ps1
+++ b/scripts/Pack-Npm.ps1
@@ -11,7 +11,7 @@ if ($Trace) {
 
 . $PSScriptRoot\helpers.ps1 | out-null
 
-$srcDir = Join-Path $rootDirectory 'build\packages'
+$srcDir = Join-Path $rootDirectory 'src'
 
 $targetDir = Join-Path $rootDirectory 'build\npm'
 
@@ -20,16 +20,6 @@ New-Item -itemtype Directory -Path $targetDir -Force -ErrorAction SilentlyContin
 
 try {
 	Push-Location (Join-Path $srcDir "com.unity.git")
-	$package = Invoke-Command -Fatal { & npm pack -q }
-	$package = "$package".Trim()
-	$tgt = Join-Path $targetDir $package
-	Move-Item $package $tgt -Force
-} finally {
-    Pop-Location
-}
-
-try {
-	Push-Location (Join-Path $srcDir "com.unity.git.tests")
 	$package = Invoke-Command -Fatal { & npm pack -q }
 	$package = "$package".Trim()
 	$tgt = Join-Path $targetDir $package


### PR DESCRIPTION
### Requirements

- 

### Description of the Change

When I try to pack tarball package with `pack.cmd -r -b`. I got the result: 

```
Push-Location : Cannot find path 'C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\build\packages\com.unity.git'
because it does not exist.
At C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\scripts\Pack-Npm.ps1:22 char:2
+     Push-Location (Join-Path $srcDir "com.unity.git")
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\WingyM...s\com.unity.git:String) [Push-Location], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.PushLocationCommand

npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\WingyMomo\scoop\persist\nodejs\cache\_logs\2020-11-15T17_11_01_463Z-debug.log
` & npm pack -q ` failed
At C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\scripts\helpers.ps1:35 char:9
+         Throw (New-Object -TypeName ScriptException -ArgumentList $me ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], ScriptException
    + FullyQualifiedErrorId : ` & npm pack -q ` failed
```

That's probably because of `$srcDir` point to `build/packages` which is doesn't exists. So I change it to `$rootDir\src`. But after that, I found a new error that `com.unity.git.tests` doesn't exists. So I decide to remove it because I found that this namespace living inside `com.unity.git`. This is the build result after I solved the first issue.

```
Push-Location : Cannot find path 'C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\src\com.unity.git.tests' because it
does not exist.
At C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\scripts\Pack-Npm.ps1:32 char:2
+     Push-Location (Join-Path $srcDir "com.unity.git.tests")
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\WingyM...unity.git.tests:String) [Push-Location], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.PushLocationCommand

npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\WingyMomo\scoop\persist\nodejs\cache\_logs\2020-11-15T17_14_55_079Z-debug.log
` & npm pack -q ` failed
At C:\Users\WingyMomo\src\github.com\Unity-Technologies\Git-for-Unity\scripts\helpers.ps1:35 char:9
+         Throw (New-Object -TypeName ScriptException -ArgumentList $me ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], ScriptException
    + FullyQualifiedErrorId : ` & npm pack -q ` failed
```

### Alternate Designs

-
### Benefits

-

### Possible Drawbacks

- 

### Applicable Issues

- 
